### PR TITLE
フラッシュメッセージの実装

### DIFF
--- a/app/assets/stylesheets/_flash.scss
+++ b/app/assets/stylesheets/_flash.scss
@@ -1,0 +1,10 @@
+.flash {
+  color: white;
+  text-align: center;
+  &__alert{
+    background-color: #D65F4C;
+  }
+  &__notice {
+    background-color: #38AEF0;
+  }
+}

--- a/app/assets/stylesheets/_style.scss
+++ b/app/assets/stylesheets/_style.scss
@@ -1,8 +1,6 @@
-header {
-  background-color: #38AEF0;
-  color: white;
-  text-align: center;
-  height: $header-height;
+body {
+  width: 100vw;
+  height: 100vh;
 }
 
 .side {

--- a/app/assets/stylesheets/_variable.scss
+++ b/app/assets/stylesheets/_variable.scss
@@ -1,8 +1,7 @@
 $aicon-text-color: #FFFFFF;
 $Light-color: #999999;
-$header-height: 4vh;
-$side-user-bar-height: 14vh;
-$side-group-bar-height: 82vh;
-$group-infomation-height: 14vh;
-$chat-area-height: calc(69vh - 46px);
-$posting-message-area-hright: calc(13vh - 20px);
+$side-user-bar-height: 16vh;
+$side-group-bar-height: 84vh;
+$group-infomation-height: 16vh;
+$chat-area-height: calc(71vh - 46px);
+$posting-message-area-hright: calc(13vh - 21px);

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,3 +4,4 @@
 @import "./style.scss";
 @import "font-awesome";
 @import "./user.scss";
+@import "./flash.scss";

--- a/app/views/layouts/_flash.html.haml
+++ b/app/views/layouts/_flash.html.haml
@@ -1,0 +1,2 @@
+- flash.each do |key, value|
+  = content_tag(:div, value, class: "flash flash__#{key}")

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,4 +7,5 @@
     = javascript_include_tag 'application', 'data-turbolinks-track' => true
     = csrf_meta_tags
   %body
+    = render 'layouts/flash'
     = yield

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -3,7 +3,6 @@
   %head
     %meta{charset: "utf-8"}
   %body
-    %header チャットグループが作成されました。
     .side
       .side__user
         = link_to edit_user_path(current_user) do

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,7 @@ module ChatSpace
     config.generators.javascripts    = false
     config.generators.helper         = false
     config.generators.test_framework = false
+    config.i18n.default_locale       = :ja
   end
 end
 

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,59 @@
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+# Japanese translation for devise
+
+ja:
+  errors:
+    messages:
+      expired: "有効期限切れです。新規登録してください"
+      not_found: "は見つかりませんでした"
+      already_confirmed: "は既に登録済みです。ログインしてください"
+      not_locked: "ロックされていません"
+      not_saved:
+        one: "エラーにより、この %{resource} を保存できません："
+        other: "%{count} 個のエラーにより、この %{resource} を保存できません："
+
+  devise:
+    failure:
+      already_authenticated: 'ログイン済みです'
+      unauthenticated: 'ログインまたは登録が必要です。'
+      unconfirmed: '本登録を行ってください'
+      locked: 'アカウントはロックされています'
+      invalid: 'メールアドレスまたはパスワードが違います'
+      invalid_token: '認証キーが不正です'
+      timeout: '一定時間が経過したため、再度ログインが必要です'
+      inactive: 'アカウントがまだ有効になっていません'
+    sessions:
+      signed_in: 'ログインしました。'
+      signed_out: 'ログアウトしました'
+    passwords:
+      send_instructions: 'パスワードのリセット方法を数分以内にメールでご連絡します'
+      updated: 'パスワードを変更しました。ログイン済みです'
+      updated_not_active: 'パスワードを変更しました'
+      send_paranoid_instructions: "ご登録のメールアドレスが保存されている場合、パスワード復旧用のリンク先をメールでご連絡します"
+    confirmations:
+      send_instructions: 'アカウントの確認方法を数分以内にメールでご連絡します'
+      send_paranoid_instructions: 'ご登録のメールアドレスが保存されている場合、アカウントの確認方法をメールでご連絡します'
+      confirmed: 'アカウントが確認されました。ログインしています'
+    registrations:
+      signed_up: 'アカウントが登録されました。'
+      inactive_signed_up: 'アカウントが登録されましたが、ログインできませんでした。理由：%{reason}'
+      updated: 'アカウントが更新されました'
+      destroyed: 'ご利用ありがとうございました。アカウントが削除されました。またのご利用をお待ちしています'
+      reasons:
+        inactive: 'アクティブでない'
+        unconfirmed: '未確認の'
+        locked: 'ロックされている'
+    unlocks:
+      send_instructions: 'アカウントのロックを解除する方法を数分以内にメールでご連絡します'
+      unlocked: 'アカウントのロックが解除されました。ログインしています。'
+      send_paranoid_instructions: 'アカウントが存在する場合、ロックを解除する方法をメールでご連絡します'
+    omniauth_callbacks:
+      success: '%{kind} から承認されました。'
+      failure: '%{kind} から承認されませんでした。理由："%{reason}".'
+    mailer:
+      confirmation_instructions:
+        subject: 'アカウントの登録方法'
+      reset_password_instructions:
+        subject: 'パスワードの再設定'
+      unlock_instructions:
+        subject: 'アカウントのロック解除'


### PR DESCRIPTION
# WHAT
- フラッシュメッセージの実装

# WHY
- ユーザーの動作に合わせて何が行われたか、何を行えばいいのかを認識させるため。


## ビューの参考画像

### ▼サインアップ時のフラッシュメッセージ
![default](https://cloud.githubusercontent.com/assets/17684115/26782486/d39ff68e-4a2e-11e7-9a46-f8b7817241d4.png)


### ▼サインイン時のフラッシュメッセージ
![default](https://cloud.githubusercontent.com/assets/17684115/26782493/df264bca-4a2e-11e7-827e-baf2aa2b904b.png)


### ▼ログアウト時のフラッシュメッセージ
![default](https://cloud.githubusercontent.com/assets/17684115/26782506/ee93975c-4a2e-11e7-9807-a29ce46928c0.png)
