### PR TITLE
グループ名をサイドバーに表示＆グループ編集機能

### DIFF
--- a/app/assets/stylesheets/_mixin.scss
+++ b/app/assets/stylesheets/_mixin.scss
@@ -1,5 +1,5 @@
 @mixin aicon-style() {
-  color: $aicon-text-color;
+  color: $white-color;
   font-size: 20px;
   float: right;
   padding-top: 45px;
@@ -10,11 +10,11 @@
   padding-top: 5px;
   padding-bottom: 40px;
   font-size: 11px;
-  color: $aicon-text-color;
+  color: $white-color;
 }
 
 @mixin group-name-style() {
   padding-top: 20px;
   font-size: 15px;
-  color: $aicon-text-color;
+  color: $white-color;
 }

--- a/app/assets/stylesheets/_style.scss
+++ b/app/assets/stylesheets/_style.scss
@@ -18,7 +18,7 @@ body {
       padding-right: 10px;
     }
     &__user-name {
-      color: $aicon-text-color;
+      color: $white-color;
       font-size: 16px;
       font-weight: bold;
       padding-top: 40px;
@@ -40,10 +40,11 @@ body {
 }
 
 .chat-screen {
-  background-color: #AAAAAA;
+  background-color: #FAFAFA;
   width: calc(100vw - 300px);
   float: left;
   &__group {
+    background-color: #FFFFFF;
     height: $group-infomation-height;
     padding-left: 40px;
     padding-right:40px;
@@ -102,7 +103,7 @@ body {
     padding-top: 20px;
     &__message-box {
       float: left;
-      background-color: gray;
+      background-color: $white-color;
       height: 50px;
       width: 940px;
       text-align: 10px;
@@ -113,7 +114,7 @@ body {
         padding-right: 10px;
         padding-top: 15px;
         font-size: 20px;
-        color: $aicon-text-color;
+        color: $white-color;
       }
     }
     &__message-send-btn {
@@ -125,7 +126,7 @@ body {
       margin-left: 15px;
       text-align: center;
       line-height: 50px;
-      color: white;
+      color: $white-color;
     }
   }
 }

--- a/app/assets/stylesheets/_variable.scss
+++ b/app/assets/stylesheets/_variable.scss
@@ -1,4 +1,4 @@
-$aicon-text-color: #FFFFFF;
+$white-color: #FFFFFF;
 $Light-color: #999999;
 $side-user-bar-height: 16vh;
 $side-group-bar-height: 84vh;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -4,7 +4,19 @@ class GroupsController < ApplicationController
   end
 
   def edit
-    @group = Group.new
+    @group = Group.find(params[:id])
+  end
+
+  def update
+    @group = Group.find(params[:id])
+
+    if @group.update(group_params)
+      flash[:notice] = "チャットグループが更新されました。"
+      redirect_to root_path
+    else
+      flash[:alert] = "チャットグループの更新に失敗しました。"
+      render :edit
+    end
   end
 
   def create

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,5 @@
 class GroupsController < ApplicationController
-  before_action :move_edit, only:[:edit,:update]
+  before_action :get_group, only:[:edit,:update]
 
   def new
     @group = Group.new
@@ -33,10 +33,10 @@ class GroupsController < ApplicationController
 
   private
   def group_params
-    params.require(:group).permit(:name)
+    params.require(:group).permit(:name, {user_ids:[]})
   end
 
-  def move_edit
+  def get_group
     @group = Group.find(params[:id])
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,15 +1,14 @@
 class GroupsController < ApplicationController
+  before_action :move_edit, only:[:edit,:update]
+
   def new
     @group = Group.new
   end
 
   def edit
-    @group = Group.find(params[:id])
   end
 
   def update
-    @group = Group.find(params[:id])
-
     if @group.update(group_params)
       flash[:notice] = "チャットグループが更新されました。"
       redirect_to root_path
@@ -35,5 +34,9 @@ class GroupsController < ApplicationController
   private
   def group_params
     params.require(:group).permit(:name)
+  end
+
+  def move_edit
+    @group = Group.find(params[:id])
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,5 +2,6 @@ class MessagesController < ApplicationController
   before_action :authenticate_user!
 
   def index
+    @groups = Group.all
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,6 +2,6 @@ class MessagesController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @groups = Group.all
+    @groups = current_user.groups
   end
 end

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,16 +1,20 @@
 .chat-group-form
   %h1 チャットグループ編集
-  %form#edit_chat_group_22.edit_chat_group{"accept-charset" => "UTF-8", :action => "/chat_groups/22", :method => "post"}
-    / .chat-group-form__errors
-    /   %h2
-    /     1件のエラーが発生しました。
-    /     %ul
-    /       %li エラーです
+  = form_for @group do |f|
+    - if @group.errors.any?
+      .chat-group-form__errors
+        %h2
+          = @group.errors.count
+          件のエラーが発生しました。
+          %ul
+            - @group.errors.full_messages.each do |msg|
+              %li
+                = msg
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
-        %label.chat-group-form__label{:for => "chat_group_name"} グループ名
+        = f.label :name, "グループ名", class: "chat-group-form__label"
       .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{:name => "chat_group[name]", :placeholder => "グループ名を入力してください", :type => "text", :value => "ほげー"}/
+        = f.text_field :name, class: "chat-group-form__input", palaceholder: "グループ名を入力してください"
     .chat-group-form__field.clearfix
       / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
       /
@@ -25,7 +29,7 @@
         </div>
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
-        %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+        = f.label :user_ids, "チャットメンバー", class: "chat-group-form__label"
       .chat-group-form__field--right
         / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
         = render 'groups/collection_check_boxes'

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -13,14 +13,11 @@
         .side__user__user-name
           = current_user.name
       .side__group
-        .side__group__name group1
-        .side__group__message まだメッセージはありません
-
-        .side__group__name group2
-        .side__group__message あなたには誰からもメッセージはありません
-
-        .side__group__name group3
-        .side__group__message (´；ω；｀)ﾌﾞﾜｯ
+        - @groups.each do |group|
+          / = link_to group_messages_path do
+          .side__group__name
+            = group.name
+          .side__group__message まだメッセージはありません
 
     .chat-screen
       .chat-screen__group


### PR DESCRIPTION
# WHAT
- グループ名をサイドバーに表示
- グループ名を編集
- 編集成功時と失敗時に合わせたフラッシュメッセージの実装

# WHY
- 必要機能なため

### ▼グループ名をサイドバーに表示 ###
![default](https://user-images.githubusercontent.com/17684115/26959770-e29c41ca-4d0c-11e7-96a4-29c2d95c4327.png)

### ▼編集画面 ###
![default](https://user-images.githubusercontent.com/17684115/26959714-82db81f6-4d0c-11e7-93f3-d01f669c511c.png)

### ▼グループ編集成功時 ###
![default](https://user-images.githubusercontent.com/17684115/26959725-8cd1fb54-4d0c-11e7-9d78-efdb1788e8e0.png)

### ▼グループ編集失敗時 ###
![default](https://user-images.githubusercontent.com/17684115/26959732-98af1132-4d0c-11e7-913f-e180c08d9ec1.png)


