### PR TITLE
ルートパス修正＆グループ名リンク化

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :authenticate_user!
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,10 @@
 class GroupsController < ApplicationController
+  before_action :authenticate_user!
   before_action :get_group, only:[:edit,:update]
+
+  def index
+    @groups = current_user.groups
+  end
 
   def new
     @group = Group.new

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,5 @@
 class GroupsController < ApplicationController
-  before_action :authenticate_user!
+  
   before_action :get_group, only:[:edit,:update]
 
   def index

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,6 +1,4 @@
 class MessagesController < ApplicationController
-  before_action :authenticate_user!
-
   def index
     @groups = current_user.groups
   end

--- a/app/views/groups/_side_bar.haml
+++ b/app/views/groups/_side_bar.haml
@@ -1,0 +1,21 @@
+!!!
+%html{lang: "ja"}
+  %head
+    %meta{charset: "utf-8"}
+  %body
+    .side
+      .side__user
+        = link_to edit_user_path(current_user) do
+          %i.fa.fa-cog{"aria-hidden" => "true"}
+        = link_to new_group_path do
+          %i.fa.fa-edit{"aria-hidden" => "true"}
+
+        .side__user__user-name
+          = current_user.name
+      .side__group
+        - @groups.each do |group|
+          / = link_to group_messages_path do
+          = link_to group_messages_path(group.id) do
+            .side__group__name
+              = group.name
+          .side__group__message まだメッセージはありません

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,0 +1,1 @@
+= render 'groups/side_bar'

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,1 +1,1 @@
-= render 'groups/side_bar'
+= render 'shared/side_bar'

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,47 +1,29 @@
-!!!
-%html{lang: "ja"}
-  %head
-    %meta{charset: "utf-8"}
-  %body
-    .side
-      .side__user
-        = link_to edit_user_path(current_user) do
-          %i.fa.fa-cog{"aria-hidden" => "true"}
-        = link_to new_group_path do
-          %i.fa.fa-edit{"aria-hidden" => "true"}
+= render 'groups/side_bar'
 
-        .side__user__user-name
-          = current_user.name
-      .side__group
-        - @groups.each do |group|
-          / = link_to group_messages_path do
-          .side__group__name
-            = group.name
-          .side__group__message まだメッセージはありません
+.chat-screen
+  .chat-screen__group
+    = link_to edit_group_path(current_user) do
+      .chat-screen__group__edit-btn Edit
+    .chat-screen__group__name bbbbb
+    .chat-screen__group__create-user
+      = "Members: #{current_user.name}"
 
-    .chat-screen
-      .chat-screen__group
-        = link_to edit_group_path(current_user) do
-          .chat-screen__group__edit-btn Edit
-        .chat-screen__group__name sample group
-        .chat-screen__group__create-user Members: a
+  .chat-screen__chat-area
+    .chat-screen__chat-area__message-name UserName1
+    .chat-screen__chat-area__message-time 2017/6/1 11:30:18
+    .chat-screen__chat-area__message haha! zenzendekinai...warota!
 
-      .chat-screen__chat-area
-        .chat-screen__chat-area__message-name UserName1
-        .chat-screen__chat-area__message-time 2017/6/1 11:30:18
-        .chat-screen__chat-area__message haha! zenzendekinai...warota!
+    .chat-screen__chat-area__message-name UserName2
+    .chat-screen__chat-area__message-time 2017/6/1 13:51:21
+    .chat-screen__chat-area__message すすまない…(´・ω・｀)
 
-        .chat-screen__chat-area__message-name UserName2
-        .chat-screen__chat-area__message-time 2017/6/1 13:51:21
-        .chat-screen__chat-area__message すすまない…(´・ω・｀)
+    .chat-screen__chat-area__message-name UserName3
+    .chat-screen__chat-area__message-time 2017/6/1 15:43:09
+    .chat-screen__chat-area__message (´；ω；｀)ﾌﾞﾜｯ
 
-        .chat-screen__chat-area__message-name UserName3
-        .chat-screen__chat-area__message-time 2017/6/1 15:43:09
-        .chat-screen__chat-area__message (´；ω；｀)ﾌﾞﾜｯ
-
-      .chat-screen__posting-area
-        .chat-screen__posting-area__message-box
-          type a message
-          %i.fa.fa-picture-o{"aria-hidden" => "true"}
-        .chat-screen__posting-area__message-send-btn Send
-    %footer
+  .chat-screen__posting-area
+    .chat-screen__posting-area__message-box
+      type a message
+      %i.fa.fa-picture-o{"aria-hidden" => "true"}
+    .chat-screen__posting-area__message-send-btn Send
+%footer

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,4 +1,4 @@
-= render 'groups/side_bar'
+= render 'shared/side_bar'
 
 .chat-screen
   .chat-screen__group

--- a/app/views/shared/_side_bar.haml
+++ b/app/views/shared/_side_bar.haml
@@ -6,15 +6,14 @@
     .side
       .side__user
         = link_to edit_user_path(current_user) do
-          %i.fa.fa-cog{"aria-hidden" => "true"}
+          %i.fa.fa-cog{"aria-hidden": true}
         = link_to new_group_path do
-          %i.fa.fa-edit{"aria-hidden" => "true"}
+          %i.fa.fa-edit{"aria-hidden": true}
 
         .side__user__user-name
           = current_user.name
       .side__group
         - @groups.each do |group|
-          / = link_to group_messages_path do
           = link_to group_messages_path(group.id) do
             .side__group__name
               = group.name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  root 'messages#index'
+  root 'groups#index'
   resources :users, only:[:edit, :update]
   resources :groups,except:[:destroy] do
     resources :messages, only: :index


### PR DESCRIPTION
# WHAT
- ルートパスを修正
- ルートアクセス時、サイドバーのみ表示
- グループ名リンク化

# WHY
必要機能なため

### ▼ルートパスアクセス時 ###
![default](https://user-images.githubusercontent.com/17684115/26964010-a790475c-4d2a-11e7-9847-c079adf0e9dc.png)

### ▼グループクリック後 ###
![default](https://user-images.githubusercontent.com/17684115/26964016-adc33602-4d2a-11e7-8e94-6a72101b7eee.png)
