### PR TITLE
メッセージ投稿の非同期通信化

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -5,7 +5,7 @@ $(function() {
     var name = '<p class="chat-screen__chat-area__message-name">'+ message.name +'</p>';
     var time = '<p class="chat-screen__chat-area__message-time">'+ message.time + '<p>';
     var body = '<p class ="chat-screen__chat-area__message">' + message.body +'</p>';
-    if( message.image ) {
+    if(message.image) {
       var image_url = '<img src = "' + message.image + '">';
       var image = '<p class ="chat-screen__chat-area__image">' + image_url +'</p>';
     } else {
@@ -17,6 +17,7 @@ $(function() {
   $('.message-form'). on('submit', function(e){
     e.preventDefault();
     e.stopPropagation();
+    var $form = $('.message-form');
     var formData = new FormData ($(this).get(0));
     var url = $(this).attr("action");
     $.ajax ({
@@ -29,8 +30,7 @@ $(function() {
     })
     .done(function(message) {
       buildHTML(message);
-      // textField.val('');
-      $('.message-form')[0].reset();
+      $form[0].reset();
       $('.chat-screen__chat-area').animate({scrollTop: $('.chat-screen__chat-area')[0].scrollHeight}, 'fast');
     })
     .fail(function() {

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,37 @@
+$(function() {
+  function buildHTML(message) {
+    // var create_message = $(
+      // '<div class="chat-screen__chat-area">' +
+    var name = '<p class="chat-screen__chat-area__message-name">'+ message.name +'</p>'
+    var time = '<p class="chat-screen__chat-area__message-time">'+ message.time + '<p>'
+    var body = '<p class ="chat-screen__chat-area__message">' + message.body +'</p>'
+    if( message.image ) {
+      var image_url = '<img src = "' + message.image + '">'
+      var image = '<p class ="chat-screen__chat-area__image">' + image_url +'</p>'
+    };
+    var image = '<p class ="chat-screen__chat-area__image"></p>'
+    $('.chat-screen__chat-area').append(name, time, body, image);
+  }
+
+  $('.message-form'). on('submit', function(e){
+    e.preventDefault();
+    e.stopPropagation();
+    var formData = new FormData ($(this).get(0));
+    var url = $(this).attr("action")
+    $.ajax ({
+      type:'POST',
+      url: url,
+      data: formData,
+      processData: false,
+      contentType: false,
+      dataType: 'json'
+    })
+    .done(function(message) {
+      buildHTML(message);
+      textField.val('');
+    })
+    .fail(function() {
+      alert('error');
+    });
+  });
+});

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,22 +2,23 @@ $(function() {
   function buildHTML(message) {
     // var create_message = $(
       // '<div class="chat-screen__chat-area">' +
-    var name = '<p class="chat-screen__chat-area__message-name">'+ message.name +'</p>'
-    var time = '<p class="chat-screen__chat-area__message-time">'+ message.time + '<p>'
-    var body = '<p class ="chat-screen__chat-area__message">' + message.body +'</p>'
+    var name = '<p class="chat-screen__chat-area__message-name">'+ message.name +'</p>';
+    var time = '<p class="chat-screen__chat-area__message-time">'+ message.time + '<p>';
+    var body = '<p class ="chat-screen__chat-area__message">' + message.body +'</p>';
     if( message.image ) {
-      var image_url = '<img src = "' + message.image + '">'
-      var image = '<p class ="chat-screen__chat-area__image">' + image_url +'</p>'
+      var image_url = '<img src = "' + message.image + '">';
+      var image = '<p class ="chat-screen__chat-area__image">' + image_url +'</p>';
+    } else {
+      var image = '<p class ="chat-screen__chat-area__image"></p>';
     };
-    var image = '<p class ="chat-screen__chat-area__image"></p>'
     $('.chat-screen__chat-area').append(name, time, body, image);
-  }
+  };
 
   $('.message-form'). on('submit', function(e){
     e.preventDefault();
     e.stopPropagation();
     var formData = new FormData ($(this).get(0));
-    var url = $(this).attr("action")
+    var url = $(this).attr("action");
     $.ajax ({
       type:'POST',
       url: url,
@@ -28,7 +29,9 @@ $(function() {
     })
     .done(function(message) {
       buildHTML(message);
-      textField.val('');
+      // textField.val('');
+      $('.message-form')[0].reset();
+      $('.chat-screen__chat-area').animate({scrollTop: $('.chat-screen__chat-area')[0].scrollHeight}, 'fast');
     })
     .fail(function() {
       alert('error');

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -6,7 +6,7 @@ $(function() {
     var time = '<p class="chat-screen__chat-area__message-time">'+ message.time + '<p>';
     var body = '<p class ="chat-screen__chat-area__message">' + message.body +'</p>';
     if(message.image) {
-      var image_url = '<img src = "' + message.image + '">';
+      var image_tag = '<img src = "' + message.image + '">';
       var image = '<p class ="chat-screen__chat-area__image">' + image_url +'</p>';
     } else {
       var image = '<p class ="chat-screen__chat-area__image"></p>';

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -6,10 +6,14 @@ class MessagesController < ApplicationController
   end
 
   def create
-    @message = @group.messages.new(message_params)
+    @message = Group.find(params[:group_id]).messages.new(message_params)
     if @message.save
-      flash[:notice] = "メッセージ投稿が完了しました。"
-      redirect_to group_messages_path
+      respond_to do |format|
+        format.html { redirect_to group_messages_path, notice: "メッセージが投稿されました" }
+        format.json
+      end
+      # flash[:notice] = "メッセージ投稿が完了しました。"
+      # redirect_to group_messages_path
     else
       flash[:alert] = "メッセージを入力してください。"
       render "index"

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -12,8 +12,6 @@ class MessagesController < ApplicationController
         format.html { redirect_to group_messages_path, notice: "メッセージが投稿されました" }
         format.json
       end
-      # flash[:notice] = "メッセージ投稿が完了しました。"
-      # redirect_to group_messages_path
     else
       flash[:alert] = "メッセージを入力してください。"
       render "index"

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.name @message.user.name
+json.body @message.body
+json.image @message.image.url
+json.time @message.created_at.strftime("%Y/%m/%d %H:%M:%S")

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -22,7 +22,7 @@
       .chat-screen__chat-area__image
         = image_tag msg.image
   .chat-screen__posting-area
-    = form_for [@group, @message] do |f|
+    = form_for [@group, @message], html: { class: 'form message-form' } do |f|
       = f.text_field :body, class: "chat-screen__posting-area__message-box", placeholder: " type a message"
       = f.label "image", { class: "fa fa-picture-o"} do
         = f.file_field :image, style: "display: none;"


### PR DESCRIPTION
# WHAY
- メッセージ投稿の非同期通信化
- メッセージ投稿した際に、画面最下部にスクロール
- メッセージテキストと画像が無い場合にエラーのアラート表示

# WHY
- UXの向上のため

### メッセージのみ投稿テストgif ###
![default](https://user-images.githubusercontent.com/17684115/27224144-8a92ff1a-52ce-11e7-9f69-2bcbea36a24f.gif)

### メッセージと画像投稿テストgif ###
![default](https://user-images.githubusercontent.com/17684115/27224156-945d74a8-52ce-11e7-9438-d37366f8c5c7.gif)

### エラーテストgif ###
![default](https://user-images.githubusercontent.com/17684115/27224167-9f897854-52ce-11e7-9f19-024085151834.gif)


